### PR TITLE
Add package version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,13 +28,13 @@ def find_version(*file_paths):
 
 
 install_requires = [
-    'pyOpenSSL',
-    'ndg-httpsclient',
-    'pyasn1',
-    'easywebdav',
-    'oerplib',
-    'pybase64',
-    'Office365-REST-Python-Client'
+    'pyOpenSSL==19.1.0',
+    'ndg-httpsclient==0.5.1',
+    'pyasn1==0.4.8',
+    'easywebdav==1.2.0',
+    'oerplib==0.8.4',
+    'pybase64==0.5.0',
+    'Office365-REST-Python-Client==2.1.5'
 ]
 
 tests_require = [


### PR DESCRIPTION
Since ufload is not working with the newest version of
Office-365-REST-Python-Client package, I had to secure that the last
working version will be installed - 2.1.5

I have done this also for other packages based on pip freeze of working
installation.

I have tested ls and restore command for random instance. 

However one of the tests isn't running even in the previous version. 
