### PR TITLE
Changes to get_onedrive_connection function

### DIFF
--- a/ufload/cloud.py
+++ b/ufload/cloud.py
@@ -97,11 +97,14 @@ def get_onedrive_connection(args):
     path = info.get('site') + url.path
 
     try:
-        dav = webdav.Client(url.netloc, port=url.port, protocol=url.scheme, username=info['login'], password=info['password'], path=path)
+        dav = webdav.Client(url.netloc, port=url.port, protocol=url.scheme, username=info['login'],
+                            password=info['password'], path=path)
+        return dav
     except webdav.ConnectionFailed, e:
-        ufload.progress('Unable to connect: %s') % (e.message)
+        ufload.progress('Unable to connect: {}'.format(e))
+        ufload.progress('Cannot proceed without connection, exiting program.')
+        exit(1)
 
-    return dav
 
 
 


### PR DESCRIPTION
- moved return statement into try branch - without this is dav variable
  refferenced before assighnment if you end up in except branch
- fixed problem with string concat in except branch - used more moder
  approach with fortmat (if you actually hit except branch the original
  code would fail at concat str and NoneType)
- added exit(1) to except branch, it doesn't make sense to continue
  running without dav variable and since there is no check in other
  parts if dav is not None etc, it is easier to fix it this way.